### PR TITLE
Add MacOS support

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,9 +16,15 @@ OPT_ := ${OPT_DEBUG}
 OPT := ${OPT_${MODE}}
 CFLAGS += ${OPT} -Wall -Wextra -Wpedantic -std=c99 -ferror-limit=15
 
-LIBS := -lglfw -lm -framework Cocoa -framework IOKit -framework OpenGL
+LIBS := -lglfw -lGL -lm
+LIBS_MACOS := -lglfw -lm -framework Cocoa -framework IOKit -framework OpenGL
 
 default: build_lite_engine
+
+build_lite_engine_macos:	build_dir \
+										build_glad
+	${C} ${OBJFILES} ${SRCFILES} ${INCDIR} ${LIBS_MACOS} ${CFLAGS} -o ${OUT}
+	time ./${OUT}
 
 build_lite_engine:	build_dir \
 										build_glad

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ OPT_ := ${OPT_DEBUG}
 OPT := ${OPT_${MODE}}
 CFLAGS += ${OPT} -Wall -Wextra -Wpedantic -std=c99 -ferror-limit=15
 
-LIBS := -lglfw -lGL -lm 
+LIBS := -lglfw -lm -framework Cocoa -framework IOKit -framework OpenGL
 
 default: build_lite_engine
 

--- a/res/shaders/diffuse.fs.glsl
+++ b/res/shaders/diffuse.fs.glsl
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 
 int LIGHT_POINT = 0;
 int LIGHT_SPOT = 1;

--- a/res/shaders/diffuse.vs.glsl
+++ b/res/shaders/diffuse.vs.glsl
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 
 layout (location = 0) in vec3 aPos;
 layout (location = 1) in vec2 aTexCoord;

--- a/res/shaders/diffuse_font.fs.glsl
+++ b/res/shaders/diffuse_font.fs.glsl
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 
 in vec2 texCoord;
 out vec4 color;

--- a/res/shaders/diffuse_font.vs.glsl
+++ b/res/shaders/diffuse_font.vs.glsl
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 
 layout (location = 0) in vec4 vertex;
 out vec2 texCoord;

--- a/res/shaders/gizmos.fs.glsl
+++ b/res/shaders/gizmos.fs.glsl
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 
 out vec4 FragColor;
 

--- a/res/shaders/gizmos.vs.glsl
+++ b/res/shaders/gizmos.vs.glsl
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 
 layout (location = 0) in vec3 aPos;
 

--- a/res/shaders/unlit.fs.glsl
+++ b/res/shaders/unlit.fs.glsl
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 
 in vec2 texCoord;
 

--- a/res/shaders/unlit.vs.glsl
+++ b/res/shaders/unlit.vs.glsl
@@ -1,4 +1,4 @@
-#version 460 core
+#version 410 core
 
 layout (location = 0) in vec3 aPos;
 layout (location = 1) in vec2 aTexCoord;

--- a/src/main.c
+++ b/src/main.c
@@ -242,7 +242,7 @@ void lite_engine_start(void) {
 	glfwSetErrorCallback(error_callback);
 
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 6);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 	glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
 	glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);


### PR DESCRIPTION
This PR enables the engine to be built and run on macOS intel/apple silicon. I'm unsure if these changes will still allow the Linux make build directive to work despite the compiler not knowing what `-framework` means presumably. This is the first time I've really worked on a C project in a very very long time so bear with me.

The highest supported version of OpenGL on macOS (and seemingly permenantly) is 4.1. Your engine nor your shaders appear to be using 4.6 exclusive features, so if you're interested in easily supporting Windows macOS + Linux then I guess you should keep the version to this for OpenGL for now?

(edit): huh, I just watched a bit more of your source code walkthrough video, the shader result does look way different.) so maybe you really do need versions higher than 4.1. Shit.

![ScreenRecording2024-11-29at10 28 32-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/13ac4535-5cd3-4ead-a574-0017f2a97284)

(edit - again):

Never mind there's basically nothing in the shader, I've set it to wireframe mode for the gizmo cubes and it looks exactly right now.
